### PR TITLE
Update Scylla Rust driver version to 0.8.1

### DIFF
--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scylla = "0.4.7"
+scylla = "0.8.1"
 scylla-cdc = { version = "0.1.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 chrono = "0.4.19"

--- a/scylla-cdc-printer/src/printer.rs
+++ b/scylla-cdc-printer/src/printer.rs
@@ -73,7 +73,9 @@ fn print_row_change_header(data: &CDCRow<'_>) -> String {
     let mut header_to_print = String::new();
     let stream_id = data.stream_id.to_string();
     let (unix_timestamp, _) = data.time.get_timestamp().unwrap().to_unix();
-    let timestamp = NaiveDateTime::from_timestamp(unix_timestamp as i64, 0).to_string();
+    let timestamp = NaiveDateTime::from_timestamp_opt(unix_timestamp as i64, 0)
+        .unwrap()
+        .to_string();
     let operation = data.operation.to_string();
     let batch_seq_no = data.batch_seq_no.to_string();
     let end_of_batch = data.end_of_batch.to_string();

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scylla = "0.4.7"
+scylla = "0.8.1"
 scylla-cdc = { version = "0.1.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 async-trait = "0.1.51"

--- a/scylla-cdc-replicator/src/replication_tests.rs
+++ b/scylla-cdc-replicator/src/replication_tests.rs
@@ -45,7 +45,7 @@ mod tests {
         ks_src: &str,
         ks_dst: &str,
         name: &str,
-        last_read: &mut (u64, i32),
+        last_read: &mut (i64, i32),
     ) -> anyhow::Result<()> {
         let result = session
             .query(
@@ -76,7 +76,7 @@ mod tests {
 
         for log in result.rows.unwrap_or_default() {
             let cdc_row = CDCRow::from_row(log, &schema);
-            let time = cdc_row.time.get_timestamp().unwrap().to_unix_nanos();
+            let time = ReplicatorConsumer::get_timestamp(&cdc_row);
             let batch_seq_no = cdc_row.batch_seq_no;
             if (time, batch_seq_no) > *last_read {
                 *last_read = (time, batch_seq_no);

--- a/scylla-cdc-replicator/src/replicator_consumer.rs
+++ b/scylla-cdc-replicator/src/replicator_consumer.rs
@@ -369,9 +369,12 @@ impl ReplicatorConsumer {
         }
     }
 
-    fn get_timestamp(data: &CDCRow<'_>) -> i64 {
-        const NANOS_IN_MILLIS: u64 = 1000;
-        (data.time.get_timestamp().unwrap().to_unix_nanos() / NANOS_IN_MILLIS) as i64
+    /// Retrieves "cdc$time" in microseconds from a `CDCRow` object.
+    /// This can be used to replicate an operation with the exact same timestamp
+    /// as the WRITETIME function returns for a certain column.
+    pub fn get_timestamp(data: &CDCRow<'_>) -> i64 {
+        let (secs, nanos) = data.time.get_timestamp().unwrap().to_unix();
+        (secs * 1_000_000).saturating_add(nanos as u64 / 1_000) as i64
     }
 
     async fn delete_partition(&mut self, data: CDCRow<'_>) -> anyhow::Result<()> {

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.48"
 chrono = "0.4.19"
-scylla = "0.4.7"
+scylla = "0.8.1"

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.48"
-scylla = "0.4.7"
+scylla = "0.8.1"
 tokio = { version = "1.1.0", features = ["rt", "io-util", "net", "time", "macros", "sync"] }
 chrono = "0.4.19"
 futures = "0.3.17"

--- a/scylla-cdc/src/stream_reader.rs
+++ b/scylla-cdc/src/stream_reader.rs
@@ -463,14 +463,14 @@ mod tests {
 
             if pk == partition_key_1 as i32 {
                 assert_eq!(pk, partition_key_1 as i32);
-                assert_eq!(t, count1 as i32);
+                assert_eq!(t, count1);
                 assert_eq!(v.to_string(), format!("val{}", count1));
                 assert_eq!(s.to_string(), format!("static{}", count1));
                 count1 += 1;
                 row_count_with_pk1 += 1;
             } else {
                 assert_eq!(pk, partition_key_2 as i32);
-                assert_eq!(t, count2 as i32);
+                assert_eq!(t, count2);
                 assert_eq!(v.to_string(), format!("val{}", count2));
                 assert_eq!(s.to_string(), format!("static{}", count2));
                 count2 += 1;


### PR DESCRIPTION
Updates Scylla Rust driver version to the latest 0.8.1 in the CDC library and in printer and replicator applications.
Fixes some minor cargo clippy warnings related to the use of deprecated functions.