### PR TITLE
Bumped scylla version to 0.10.0

### DIFF
--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scylla = "0.8.1"
+scylla = "0.10.0"
 scylla-cdc = { version = "0.1.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 chrono = "0.4.19"

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scylla = "0.8.1"
+scylla = "0.10.0"
 scylla-cdc = { version = "0.1.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 async-trait = "0.1.51"

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.48"
 chrono = "0.4.19"
-scylla = "0.8.1"
+scylla = "0.10.0"

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.48"
-scylla = "0.8.1"
+scylla = "0.10.0"
 tokio = { version = "1.1.0", features = ["rt", "io-util", "net", "time", "macros", "sync"] }
 chrono = "0.4.19"
 futures = "0.3.17"

--- a/scylla-cdc/src/stream_generations.rs
+++ b/scylla-cdc/src/stream_generations.rs
@@ -1,10 +1,10 @@
 use futures::future::RemoteHandle;
 use futures::stream::StreamExt;
 use futures::FutureExt;
-use scylla::batch::Consistency;
 use scylla::frame::response::result::Row;
 use scylla::frame::value::Timestamp;
 use scylla::query::Query;
+use scylla::statement::Consistency;
 use scylla::{IntoTypedRows, Session};
 use std::sync::Arc;
 use std::time;

--- a/scylla-cdc/src/stream_reader.rs
+++ b/scylla-cdc/src/stream_reader.rs
@@ -286,7 +286,6 @@ impl StreamReader {
 mod tests {
     use async_trait::async_trait;
     use futures::stream::StreamExt;
-    use scylla::frame::types::LegacyConsistency;
     use scylla::query::Query;
     use scylla::transport::errors::QueryError;
     use scylla_cdc_test_utils::{now, populate_simple_db_with_pk, prepare_simple_db, TEST_TABLE};
@@ -412,7 +411,7 @@ mod tests {
         ) -> Result<QueryResult, QueryError> {
             if self.counter.fetch_sub(1, Relaxed) >= 0 {
                 let read_timeout = DbError::ReadTimeout {
-                    consistency: LegacyConsistency::Regular(Default::default()),
+                    consistency: Default::default(),
                     received: 0,
                     required: 0,
                     data_present: false,


### PR DESCRIPTION
Just bumped scylla, as this crate is not compatible anymore with the lastest version of the rust sdk.