### PR TITLE
Update scylla to 0.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "scylla-cdc",
     "scylla-cdc-printer",

--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scylla = "0.8.1"
+scylla = "0.11.1"
 scylla-cdc = { version = "0.1.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 chrono = "0.4.19"
 futures = "0.3.17"
 anyhow = "1.0.51"
 async-trait = "0.1.52"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.4", features = ["derive"] }
 
 [dev-dependencies]
 scylla-cdc-test-utils = { path = "../scylla-cdc-test-utils" }

--- a/scylla-cdc-printer/src/printer.rs
+++ b/scylla-cdc-printer/src/printer.rs
@@ -115,8 +115,9 @@ mod tests {
     use std::time;
 
     use super::*;
+    use chrono::Utc;
     use scylla_cdc::log_reader::CDCLogReaderBuilder;
-    use scylla_cdc_test_utils::{now, populate_simple_db_with_pk, prepare_simple_db, TEST_TABLE};
+    use scylla_cdc_test_utils::{populate_simple_db_with_pk, prepare_simple_db, TEST_TABLE};
 
     const SECOND_IN_MILLIS: u64 = 1_000;
     const SLEEP_INTERVAL: u64 = SECOND_IN_MILLIS / 10;
@@ -125,7 +126,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cdc_log_printer() {
-        let start = now();
+        let start = Utc::now();
         let end = start + chrono::Duration::seconds(2);
 
         let (shared_session, ks) = prepare_simple_db().await.unwrap();

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -6,17 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scylla = "0.8.1"
+scylla = "0.11.1"
 scylla-cdc = { version = "0.1.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 async-trait = "0.1.51"
 anyhow = "1.0.48"
-itertools = "0.10.3"
+itertools = "0.12.0"
 uuid = {version = "1.0.0", features = ["v1"]}
 futures-util = "0.3.19"
 tracing = "0.1.34"
 chrono = "0.4.19"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.4", features = ["derive"] }
 
 [dev-dependencies]
 scylla-cdc-test-utils = { path = "../scylla-cdc-test-utils" }

--- a/scylla-cdc-replicator/src/main.rs
+++ b/scylla-cdc-replicator/src/main.rs
@@ -4,6 +4,7 @@ pub mod replicator_consumer;
 
 use std::time::Duration;
 
+use chrono::{TimeZone, Utc};
 use clap::Parser;
 use futures_util::StreamExt;
 use tokio::select;
@@ -50,10 +51,12 @@ async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let tables: Vec<_> = args.table.split(',').map(|s| s.to_string()).collect();
     assert!(!tables.is_empty(), "no tables were provided");
-    let start_timestamp = chrono::Duration::milliseconds(match args.start_datetime {
-        Some(s) => chrono::DateTime::parse_from_rfc3339(&s)?.timestamp_millis(),
-        None => chrono::Local::now().timestamp_millis(),
-    });
+    let start_timestamp = Utc
+        .timestamp_millis_opt(match args.start_datetime {
+            Some(s) => chrono::DateTime::parse_from_rfc3339(&s)?.timestamp_millis(),
+            None => chrono::Local::now().timestamp_millis(),
+        })
+        .unwrap();
     let sleep_interval = Duration::from_secs_f64(args.sleep_interval);
     let mut result = Ok(());
 

--- a/scylla-cdc-replicator/src/replicator.rs
+++ b/scylla-cdc-replicator/src/replicator.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::time;
 
+use chrono::{DateTime, Utc};
 use futures_util::future::RemoteHandle;
 use futures_util::stream::FuturesUnordered;
 use scylla::SessionBuilder;
@@ -21,7 +22,7 @@ impl Replicator {
         dest_uri: String,
         dest_keyspace: String,
         dest_tables: Vec<String>,
-        start_timestamp: chrono::Duration,
+        start_timestamp: DateTime<Utc>,
         window_size: time::Duration,
         safety_interval: time::Duration,
         sleep_interval: time::Duration,

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.48"
 chrono = "0.4.19"
-scylla = "0.8.1"
+scylla = "0.11.1"

--- a/scylla-cdc-test-utils/src/lib.rs
+++ b/scylla-cdc-test-utils/src/lib.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use chrono::Utc;
 use scylla::query::Query;
 use scylla::statement::Consistency;
 use scylla::{Session, SessionBuilder};
@@ -8,13 +9,9 @@ use scylla::{Session, SessionBuilder};
 pub const TEST_TABLE: &str = "t";
 static UNIQUE_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-pub fn now() -> chrono::Duration {
-    chrono::Duration::milliseconds(chrono::Local::now().timestamp_millis())
-}
-
 pub fn unique_name() -> String {
     let cnt = UNIQUE_COUNTER.fetch_add(1, Ordering::SeqCst);
-    let name = format!("test_rust_{}_{}", now().num_seconds(), cnt);
+    let name = format!("test_rust_{}_{}", Utc::now().timestamp(), cnt);
     println!("unique_name: {}", name);
     name
 }

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -13,15 +13,15 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.48"
-scylla = "0.8.1"
+scylla = { version = "0.11.1", features = ["chrono", "time"] }
 tokio = { version = "1.1.0", features = ["rt", "io-util", "net", "time", "macros", "sync"] }
 chrono = "0.4.19"
 futures = "0.3.17"
 uuid = {version = "1.0.0", features = ["v1"]}
-num_enum = "0.5.4"
+num_enum = "0.7.1"
 async-trait = "0.1.51"
 tracing = "0.1.31"
-itertools = "0.10.3"
+itertools = "0.12.0"
 hex = "0.4.3"
 
 [dev-dependencies]

--- a/scylla-cdc/src/cdc_types.rs
+++ b/scylla-cdc/src/cdc_types.rs
@@ -1,19 +1,33 @@
 //! A module containing types related to CDC internal structure.
+use chrono::{DateTime, Utc};
 use scylla::cql_to_rust::{FromCqlVal, FromCqlValError};
+use scylla::frame::response::result::ColumnType;
 use scylla::frame::response::result::CqlValue;
-use scylla::frame::value::{Timestamp, Value, ValueTooBig};
+use scylla::frame::value::{CqlTimestamp, Value, ValueTooBig};
+use scylla::serialize::value::SerializeCql;
+use scylla::serialize::writers::WrittenCellProof;
 use scylla::FromRow;
 use std::fmt;
 
 /// A struct representing a timestamp of a stream generation.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, FromRow)]
 pub struct GenerationTimestamp {
-    pub timestamp: chrono::Duration,
+    pub timestamp: DateTime<Utc>,
 }
 
 impl Value for GenerationTimestamp {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
-        Timestamp(self.timestamp).serialize(buf)
+        Value::serialize(&CqlTimestamp::from(self.timestamp), buf)
+    }
+}
+
+impl SerializeCql for GenerationTimestamp {
+    fn serialize<'b>(
+        &self,
+        typ: &ColumnType,
+        writer: scylla::serialize::CellWriter<'b>,
+    ) -> Result<WrittenCellProof<'b>, scylla::serialize::SerializationError> {
+        SerializeCql::serialize(&CqlTimestamp::from(self.timestamp), typ, writer)
     }
 }
 
@@ -32,7 +46,17 @@ impl fmt::Display for StreamID {
 
 impl Value for StreamID {
     fn serialize(&self, buf: &mut Vec<u8>) -> Result<(), ValueTooBig> {
-        self.id.serialize(buf)
+        Value::serialize(&self.id, buf)
+    }
+}
+
+impl SerializeCql for StreamID {
+    fn serialize<'b>(
+        &self,
+        typ: &ColumnType,
+        writer: scylla::serialize::CellWriter<'b>,
+    ) -> Result<WrittenCellProof<'b>, scylla::serialize::SerializationError> {
+        SerializeCql::serialize(&self.id, typ, writer)
     }
 }
 


### PR DESCRIPTION
Updates scylla to use version 0.11.1, and updates other outdated dependencies.
Additionally adds `resolver = "2"` to the workspace config.