### PR TITLE
bump scylla to 0.15.1

### DIFF
--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc-printer"
-version = "0.2.0"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scylla-cdc-printer"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scylla = "0.13.1"
-scylla-cdc = { version = "0.2.0", path = "../scylla-cdc" }
+scylla = "0.15.1"
+scylla-cdc = { version = "0.3.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 chrono = "0.4.19"
 futures = "0.3.17"

--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc-printer"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc-replicator"
-version = "0.2.0"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "scylla-cdc-replicator"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scylla = "0.13.1"
-scylla-cdc = { version = "0.2.0", path = "../scylla-cdc" }
+scylla = "0.15.1"
+scylla-cdc = { version = "0.3.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 async-trait = "0.1.51"
 anyhow = "1.0.48"
 itertools = "0.13.0"
-uuid = {version = "1.0.0", features = ["v1"]}
+uuid = { version = "1.0.0", features = ["v1"] }
 futures-util = "0.3.19"
 tracing = "0.1.34"
 chrono = "0.4.19"

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc-replicator"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scylla-cdc-replicator/src/replication_tests.rs
+++ b/scylla-cdc-replicator/src/replication_tests.rs
@@ -76,7 +76,7 @@ mod tests {
         let schema = CDCRowSchema::new(result.column_specs());
 
         while let Some(log_res) = result.next().await {
-            let mut log = log_res.unwrap();
+            let mut log = log_res?;
             // handling udt specific, replacing src keyspace with dst keyspace
             for col_opt in log.columns.iter_mut().flatten() {
                 if let UserDefinedType { keyspace, .. } = col_opt {

--- a/scylla-cdc-replicator/src/replication_tests.rs
+++ b/scylla-cdc-replicator/src/replication_tests.rs
@@ -2,7 +2,7 @@
 mod tests {
     use crate::replicator_consumer::ReplicatorConsumer;
     use anyhow::anyhow;
-    use futures_util::FutureExt;
+    use futures_util::{FutureExt, StreamExt, TryStreamExt};
     use itertools::Itertools;
     use scylla::frame::response::result::CqlValue::{Boolean, Int, Text, UserDefinedType};
     use scylla::frame::response::result::{CqlValue, Row};
@@ -47,12 +47,13 @@ mod tests {
         name: &str,
         last_read: &mut (i64, i32),
     ) -> anyhow::Result<()> {
-        let result = session
-            .query(
+        let mut result = session
+            .query_iter(
                 format!("SELECT * FROM {}.{}_scylla_cdc_log", ks_src, name),
                 (),
             )
-            .await?;
+            .await?
+            .rows_stream::<Row>()?;
 
         let table_schema = session
             .get_cluster_data()
@@ -72,9 +73,10 @@ mod tests {
         )
         .await;
 
-        let schema = CDCRowSchema::new(&result.col_specs);
+        let schema = CDCRowSchema::new(result.column_specs());
 
-        for mut log in result.rows.unwrap_or_default() {
+        while let Some(log_res) = result.next().await {
+            let mut log = log_res.unwrap();
             // handling udt specific, replacing src keyspace with dst keyspace
             for col_opt in log.columns.iter_mut().flatten() {
                 if let UserDefinedType { keyspace, .. } = col_opt {
@@ -163,21 +165,23 @@ mod tests {
         name: &str,
     ) -> anyhow::Result<()> {
         let original_rows = session
-            .query(format!("SELECT * FROM {}.{}", ks_src, name), ())
+            .query_iter(format!("SELECT * FROM {}.{}", ks_src, name), ())
             .await?
-            .rows
-            .unwrap_or_default();
+            .rows_stream::<Row>()?
+            .try_collect::<Vec<_>>()
+            .await?;
         let replicated_rows = session
-            .query(format!("SELECT * FROM {}.{}", ks_dst, name), ())
+            .query_iter(format!("SELECT * FROM {}.{}", ks_dst, name), ())
             .await?
-            .rows
-            .unwrap_or_default();
+            .rows_stream::<Row>()?
+            .try_collect::<Vec<_>>()
+            .await?;
 
         if original_rows.len() == replicated_rows.len() {
             for (i, (original, replicated)) in
                 original_rows.iter().zip(replicated_rows.iter()).enumerate()
             {
-                if !equal_rows(original, replicated) {
+                if !equal_rows(&original, &replicated) {
                     fail_test(
                         name,
                         &original_rows,
@@ -207,7 +211,7 @@ mod tests {
         column_name: &str,
     ) -> anyhow::Result<(Vec<Row>, Vec<Row>)> {
         let original_rows = session
-            .query(
+            .query_iter(
                 format!(
                     "SELECT WRITETIME ({}) FROM {}.{}",
                     column_name, ks_src, table_name
@@ -215,10 +219,11 @@ mod tests {
                 (),
             )
             .await?
-            .rows
-            .unwrap_or_default();
+            .rows_stream::<Row>()?
+            .try_collect::<Vec<_>>()
+            .await?;
         let replicated_rows = session
-            .query(
+            .query_iter(
                 format!(
                     "SELECT WRITETIME ({}) FROM {}.{}",
                     column_name, ks_dst, table_name
@@ -226,8 +231,9 @@ mod tests {
                 (),
             )
             .await?
-            .rows
-            .unwrap_or_default();
+            .rows_stream::<Row>()?
+            .try_collect::<Vec<_>>()
+            .await?;
 
         Ok((original_rows, replicated_rows))
     }
@@ -327,7 +333,7 @@ mod tests {
         let mut last_read = (0, 0);
 
         for operation in operations {
-            session.query(operation, []).await?;
+            session.query_unpaged(operation, []).await?;
             replicate(
                 &session,
                 &ks_src,
@@ -800,7 +806,7 @@ mod tests {
 
         // We update timestamps for v2 column in src.
         session
-            .query(
+            .query_unpaged(
                 "UPDATE COMPARE_TIME SET v2 = false WHERE pk = 1 AND ck = 2",
                 [],
             )

--- a/scylla-cdc-replicator/src/replication_tests.rs
+++ b/scylla-cdc-replicator/src/replication_tests.rs
@@ -181,7 +181,7 @@ mod tests {
             for (i, (original, replicated)) in
                 original_rows.iter().zip(replicated_rows.iter()).enumerate()
             {
-                if !equal_rows(&original, &replicated) {
+                if !equal_rows(original, replicated) {
                     fail_test(
                         name,
                         &original_rows,

--- a/scylla-cdc-replicator/src/replicator_consumer.rs
+++ b/scylla-cdc-replicator/src/replicator_consumer.rs
@@ -311,7 +311,7 @@ async fn run_prepared_statement(
     timestamp: i64,
 ) -> anyhow::Result<()> {
     query.set_timestamp(Some(timestamp));
-    session.execute(&query, values).await?;
+    session.execute_unpaged(&query, values).await?;
 
     Ok(())
 }
@@ -323,7 +323,7 @@ async fn run_statement(
     timestamp: i64,
 ) -> anyhow::Result<()> {
     query.set_timestamp(Some(timestamp));
-    session.query(query, values).await?;
+    session.query_unpaged(query, values).await?;
 
     Ok(())
 }

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc-test-utils"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.48"
 chrono = "0.4.19"
-scylla = "0.13.1"
+scylla = "0.15.1"

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc-test-utils"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scylla-cdc-test-utils/src/lib.rs
+++ b/scylla-cdc-test-utils/src/lib.rs
@@ -34,13 +34,13 @@ pub async fn create_test_db(
     ));
     create_keyspace_query.set_consistency(Consistency::All);
 
-    session.query(create_keyspace_query, &[]).await?;
+    session.query_unpaged(create_keyspace_query, &[]).await?;
     session.await_schema_agreement().await?;
     session.use_keyspace(&ks, false).await?;
 
     // Create test tables
     for query in schema {
-        session.query(query.clone(), &[]).await?;
+        session.query_unpaged(query.clone(), &[]).await?;
     }
     session.await_schema_agreement().await?;
     Ok(ks)
@@ -49,7 +49,7 @@ pub async fn create_test_db(
 pub async fn populate_simple_db_with_pk(session: &Arc<Session>, pk: u32) -> anyhow::Result<()> {
     for i in 0..3 {
         session
-            .query(
+            .query_unpaged(
                 format!(
                     "INSERT INTO {} (pk, t, v, s) VALUES ({}, {}, 'val{}', 'static{}');",
                     TEST_TABLE, pk, i, i, i

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { version = "1.1.0", features = [
     "macros",
     "sync",
 ] }
-chrono = "0.4.19"
+chrono = "0.4.39"
 futures = "0.3.17"
 uuid = { version = "1.0.0", features = ["v1"] }
 num_enum = "0.7.2"

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Library for consuming ScyllaDB CDC log for Rust"
 repository = "https://github.com/scylladb/scylla-cdc-rust"
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.48"
-scylla = "0.13.1"
+scylla = "0.15.1"
 tokio = { version = "1.1.0", features = [
     "rt",
     "io-util",

--- a/scylla-cdc/src/checkpoints.rs
+++ b/scylla-cdc/src/checkpoints.rs
@@ -132,7 +132,7 @@ impl TableBackedCheckpointSaver {
     ) -> anyhow::Result<()> {
         let schema = get_checkpoint_table_schema(checkpoint_table);
 
-        session.query(schema, ()).await?;
+        session.query_unpaged(schema, ()).await?;
         session.await_schema_agreement().await?;
 
         Ok(())
@@ -160,7 +160,7 @@ impl CDCCheckpointSaver for TableBackedCheckpointSaver {
         let timestamp = value::CqlTimestamp(checkpoint.timestamp.as_millis() as i64);
 
         self.session
-            .execute(
+            .execute_unpaged(
                 &self.make_checkpoint_stmt,
                 (&checkpoint.generation, timestamp, &checkpoint.stream_id),
             )
@@ -174,7 +174,7 @@ impl CDCCheckpointSaver for TableBackedCheckpointSaver {
         let dummy_timestamp = value::CqlTimestamp(i64::MAX);
 
         self.session
-            .execute(
+            .execute_unpaged(
                 &self.make_checkpoint_stmt,
                 (generation, dummy_timestamp, marked_stream_id),
             )
@@ -187,7 +187,7 @@ impl CDCCheckpointSaver for TableBackedCheckpointSaver {
     async fn load_last_generation(&self) -> anyhow::Result<Option<GenerationTimestamp>> {
         let generation = self
             .session
-            .query(
+            .query_unpaged(
                 format!(
                     "SELECT generation FROM {}
                     WHERE stream_id = ?",
@@ -196,7 +196,8 @@ impl CDCCheckpointSaver for TableBackedCheckpointSaver {
                 (get_default_generation_pk(),),
             )
             .await?
-            .maybe_first_row_typed::<(GenerationTimestamp,)>()?
+            .into_rows_result()?
+            .maybe_first_row::<(GenerationTimestamp,)>()?
             .map(|row| row.0);
 
         Ok(generation)
@@ -209,7 +210,7 @@ impl CDCCheckpointSaver for TableBackedCheckpointSaver {
     ) -> anyhow::Result<Option<chrono::Duration>> {
         Ok(self
             .session
-            .query(
+            .query_unpaged(
                 format!(
                     "SELECT time FROM {}
                     WHERE stream_id = ?
@@ -219,7 +220,8 @@ impl CDCCheckpointSaver for TableBackedCheckpointSaver {
                 (stream_id,),
             )
             .await?
-            .maybe_first_row_typed::<(value::CqlTimestamp,)>()?
+            .into_rows_result()?
+            .maybe_first_row::<(value::CqlTimestamp,)>()?
             .map(|t| chrono::Duration::milliseconds(t.0 .0)))
     }
 }
@@ -230,7 +232,7 @@ mod tests {
     use crate::checkpoints::{CDCCheckpointSaver, Checkpoint, TableBackedCheckpointSaver};
     use rand::prelude::*;
     use scylla::frame::value;
-    use scylla::{IntoTypedRows, Session};
+    use scylla::Session;
     use scylla_cdc_test_utils::{prepare_db, unique_name};
     use std::ops::Add;
     use std::sync::Arc;
@@ -252,12 +254,13 @@ mod tests {
 
     async fn get_checkpoints(session: &Arc<Session>, table: &str) -> Vec<Checkpoint> {
         session
-            .query(format!("SELECT * FROM {}", table), ())
+            .query_unpaged(format!("SELECT * FROM {}", table), ())
             .await
             .unwrap()
-            .rows()
+            .into_rows_result()
             .unwrap()
-            .into_typed::<(StreamID, GenerationTimestamp, value::CqlTimestamp)>()
+            .rows::<(StreamID, GenerationTimestamp, value::CqlTimestamp)>()
+            .unwrap()
             .map(|x| x.unwrap())
             .map(|(id, gen, time)| -> Checkpoint {
                 Checkpoint {
@@ -280,7 +283,7 @@ mod tests {
                 id: vec![1, 1, 1, 1, 1, 1, 1, 1],
             },
             generation: GenerationTimestamp {
-                timestamp: chrono::Duration::min_value(),
+                timestamp: chrono::Duration::MIN,
             },
         };
 
@@ -352,7 +355,7 @@ mod tests {
                 timestamp: Duration::from_secs(random::<u64>() % (100u64 * N_OF_IDS as u64)),
                 stream_id: StreamID { id: vec![0, i] },
                 generation: GenerationTimestamp {
-                    timestamp: chrono::Duration::max_value(),
+                    timestamp: chrono::Duration::MAX,
                 },
             };
 

--- a/scylla-cdc/src/e2e_tests.rs
+++ b/scylla-cdc/src/e2e_tests.rs
@@ -13,9 +13,9 @@ mod tests {
     use itertools::{repeat_n, Itertools};
     use scylla::frame::response::result::{ColumnType, CqlValue};
     use scylla::prepared_statement::PreparedStatement;
-    use scylla::serialize::value::SerializeCql;
-    use scylla::serialize::writers::WrittenCellProof;
-    use scylla::serialize::{CellWriter, SerializationError};
+    use scylla::serialize::value::SerializeValue;
+    use scylla::serialize::writers::{CellWriter, WrittenCellProof};
+    use scylla::serialize::SerializationError;
     use scylla::Session;
     use scylla_cdc_test_utils::{now, prepare_db};
     use tokio::sync::Mutex;
@@ -40,7 +40,7 @@ mod tests {
         List(Vec<PrimaryKeyValue>),
     }
 
-    impl SerializeCql for PrimaryKeyValue {
+    impl SerializeValue for PrimaryKeyValue {
         fn serialize<'b>(
             &self,
             typ: &ColumnType,
@@ -231,7 +231,7 @@ mod tests {
             v: Option<i32>,
         ) -> Result<()> {
             self.session
-                .execute(&self.insert_query, Test::get_value_list(&pk_vec, ck, v))
+                .execute_unpaged(&self.insert_query, Test::get_value_list(&pk_vec, ck, v))
                 .await?;
             let operation = Operation::new(OperationType::RowInsert, Some(ck), v);
             self.push_back(pk_vec, operation);
@@ -246,7 +246,7 @@ mod tests {
             v: Option<i32>,
         ) -> Result<()> {
             self.session
-                .execute(&self.update_query, Test::get_value_list(&pk_vec, ck, v))
+                .execute_unpaged(&self.update_query, Test::get_value_list(&pk_vec, ck, v))
                 .await?;
             let operation = Operation::new(OperationType::RowUpdate, Some(ck), v);
             self.push_back(pk_vec, operation);

--- a/scylla-cdc/src/log_reader.rs
+++ b/scylla-cdc/src/log_reader.rs
@@ -56,7 +56,7 @@ impl CDCLogReader {
 
     // Tell the worker to stop immediately
     pub fn stop(&mut self) {
-        self.stop_at(chrono::Duration::min_value());
+        self.stop_at(chrono::Duration::MIN);
     }
 }
 
@@ -196,8 +196,7 @@ impl CDCReaderWorker {
     }
 
     async fn stop_now(&self) {
-        self.set_upper_timestamp(chrono::Duration::min_value())
-            .await;
+        self.set_upper_timestamp(chrono::Duration::MIN).await;
     }
 }
 
@@ -271,7 +270,7 @@ impl CDCLogReaderBuilder {
     /// * should_save_progress: false,
     /// * pause_between_saves: 10 seconds
     pub fn new() -> CDCLogReaderBuilder {
-        let end_timestamp = chrono::Duration::max_value();
+        let end_timestamp = chrono::Duration::MAX;
         let session = None;
         let keyspace = None;
         let table_name = None;
@@ -435,7 +434,7 @@ impl CDCLogReaderBuilder {
             anyhow::anyhow!("failed to create the cdc reader: missing consumer factory")
         })?;
 
-        let end_timestamp = chrono::Duration::max_value();
+        let end_timestamp = chrono::Duration::MAX;
         let (end_timestamp_sender, end_timestamp_receiver) =
             tokio::sync::watch::channel(end_timestamp);
         let readers = vec![];

--- a/scylla-cdc/src/stream_generations.rs
+++ b/scylla-cdc/src/stream_generations.rs
@@ -235,12 +235,10 @@ async fn get_cluster_size(session: &Session) -> anyhow::Result<usize> {
     // the coordinator which handles the query will only read local data
     // and will not contact other nodes, so the query will work with any cluster size larger than 0.
     let (peers_num,) = session
-        .query_iter("SELECT COUNT(*) FROM system.peers", &[])
+        .query_unpaged("SELECT COUNT(*) FROM system.peers", &[])
         .await?
-        .rows_stream::<(i64,)>()?
-        .next()
-        .await
-        .unwrap_or(Ok((0,)))?;
+        .into_rows_result()?
+        .first_row::<(i64,)>()?;
 
     // Query returns a number of peers in a cluster, so we need to add 1 to count current node.
     Ok(peers_num as usize + 1)

--- a/scylla-cdc/src/stream_generations.rs
+++ b/scylla-cdc/src/stream_generations.rs
@@ -1,11 +1,10 @@
 use futures::future::RemoteHandle;
 use futures::stream::StreamExt;
 use futures::FutureExt;
-use scylla::frame::response::result::Row;
 use scylla::frame::value;
 use scylla::query::Query;
 use scylla::statement::Consistency;
-use scylla::{IntoTypedRows, Session};
+use scylla::Session;
 use std::sync::Arc;
 use std::time;
 use tokio::sync::mpsc;
@@ -59,7 +58,7 @@ impl GenerationFetcher {
             .session
             .query_iter(query, &[])
             .await?
-            .into_typed::<(GenerationTimestamp,)>();
+            .rows_stream::<(GenerationTimestamp,)>()?;
 
         while let Some(generation) = rows.next().await {
             generations.push(generation?.0)
@@ -96,11 +95,13 @@ impl GenerationFetcher {
 
         let result = self
             .session
-            .query(query, (value::CqlTimestamp(time.num_milliseconds()),))
+            .query_unpaged(query, (value::CqlTimestamp(time.num_milliseconds()),))
             .await?
-            .rows;
+            .into_rows_result()?
+            .maybe_first_row::<(GenerationTimestamp,)>()?
+            .map(|(ts,)| ts);
 
-        GenerationFetcher::return_single_row(result)
+        Ok(result)
     }
 
     // Function instead of constant for testing purposes.
@@ -128,9 +129,15 @@ impl GenerationFetcher {
         let query =
             new_distributed_system_query(self.get_next_generation_query(), &self.session).await?;
 
-        let result = self.session.query(query, (generation,)).await?.rows;
+        let result = self
+            .session
+            .query_unpaged(query, (generation,))
+            .await?
+            .into_rows_result()?
+            .maybe_first_row::<(GenerationTimestamp,)>()?
+            .map(|(ts,)| ts);
 
-        GenerationFetcher::return_single_row(result)
+        Ok(result)
     }
 
     // Function instead of constant for testing purposes.
@@ -162,7 +169,7 @@ impl GenerationFetcher {
             .session
             .query_iter(query, (generation,))
             .await?
-            .into_typed::<(Vec<StreamID>,)>();
+            .rows_stream::<(Vec<StreamID>,)>()?;
 
         while let Some(next_row) = rows.next().await {
             let (ids,) = next_row?;
@@ -170,17 +177,6 @@ impl GenerationFetcher {
         }
 
         Ok(result_vec)
-    }
-
-    // Return single row containing generation.
-    fn return_single_row(row: Option<Vec<Row>>) -> anyhow::Result<Option<GenerationTimestamp>> {
-        if let Some(row) = row {
-            if let Some(generation) = row.into_typed::<(GenerationTimestamp,)>().next() {
-                return Ok(Some(generation?.0));
-            }
-        }
-
-        Ok(None)
     }
 
     pub async fn fetch_generations_continuously(
@@ -238,15 +234,14 @@ async fn get_cluster_size(session: &Session) -> anyhow::Result<usize> {
     // We are using default consistency here since the system keyspace is special and
     // the coordinator which handles the query will only read local data
     // and will not contact other nodes, so the query will work with any cluster size larger than 0.
-    let mut rows = session
-        .query("SELECT COUNT(*) FROM system.peers", &[])
+    let (rows,) = session
+        .query_unpaged("SELECT COUNT(*) FROM system.peers", &[])
         .await?
-        .rows
-        .unwrap()
-        .into_typed::<(i64,)>();
+        .into_rows_result()?
+        .first_row::<(i64,)>()?;
 
     // Query returns a number of peers in a cluster, so we need to add 1 to count current node.
-    Ok(rows.next().unwrap().unwrap().0 as usize + 1)
+    Ok(rows as usize + 1)
 }
 
 // Choose appropriate consistency level depending on the cluster size.
@@ -329,7 +324,7 @@ mod tests {
         .unwrap();
 
         session
-            .query(query, (value::CqlTimestamp(generation),))
+            .query_unpaged(query, (value::CqlTimestamp(generation),))
             .await
             .unwrap();
     }
@@ -352,7 +347,10 @@ mod tests {
         .await
         .unwrap();
 
-        session.query(query, (stream_generation,)).await.unwrap();
+        session
+            .query_unpaged(query, (stream_generation,))
+            .await
+            .unwrap();
     }
 
     // Create setup for tests.

--- a/scylla-cdc/src/stream_generations.rs
+++ b/scylla-cdc/src/stream_generations.rs
@@ -234,14 +234,14 @@ async fn get_cluster_size(session: &Session) -> anyhow::Result<usize> {
     // We are using default consistency here since the system keyspace is special and
     // the coordinator which handles the query will only read local data
     // and will not contact other nodes, so the query will work with any cluster size larger than 0.
-    let (rows,) = session
+    let (peers_num,) = session
         .query_unpaged("SELECT COUNT(*) FROM system.peers", &[])
         .await?
         .into_rows_result()?
         .first_row::<(i64,)>()?;
 
     // Query returns a number of peers in a cluster, so we need to add 1 to count current node.
-    Ok(rows as usize + 1)
+    Ok(peers_num as usize + 1)
 }
 
 // Choose appropriate consistency level depending on the cluster size.

--- a/scylla-cdc/src/stream_reader.rs
+++ b/scylla-cdc/src/stream_reader.rs
@@ -6,10 +6,12 @@ use std::time;
 
 use async_trait::async_trait;
 use itertools::Itertools;
+use scylla::frame::response::result::Row;
 use scylla::frame::value;
 use scylla::prepared_statement::PreparedStatement;
 use scylla::transport::errors::{DbError, QueryError};
-use scylla::{Bytes, QueryResult, Session};
+use scylla::transport::{PagingState, PagingStateResponse};
+use scylla::{QueryResult, Session};
 use tokio::sync::watch;
 use tokio::time::sleep;
 use tracing::{enabled, warn};
@@ -43,8 +45,8 @@ trait StreamSession: Sync + Send {
         ids: &[StreamID],
         window_begin: &value::CqlTimestamp,
         window_end: &value::CqlTimestamp,
-        paging_state: Option<Bytes>,
-    ) -> Result<QueryResult, QueryError>;
+        paging_state: PagingState,
+    ) -> Result<(QueryResult, Option<PagingState>), QueryError>;
 }
 
 #[async_trait]
@@ -59,10 +61,17 @@ impl StreamSession for Session {
         ids: &[StreamID],
         window_begin: &value::CqlTimestamp,
         window_end: &value::CqlTimestamp,
-        paging_state: Option<Bytes>,
-    ) -> Result<QueryResult, QueryError> {
-        self.execute_paged(statement, (ids, window_begin, window_end), paging_state)
-            .await
+        paging_state: PagingState,
+    ) -> Result<(QueryResult, Option<PagingState>), QueryError> {
+        let (query_result, paging_state_response) = self
+            .execute_single_page(statement, (ids, window_begin, window_end), paging_state)
+            .await?;
+        let next_paging_state = match paging_state_response {
+            PagingStateResponse::HasMorePages { state } => Some(state),
+            PagingStateResponse::NoMorePages => None,
+        };
+
+        Ok((query_result, next_paging_state))
     }
 }
 
@@ -122,7 +131,7 @@ impl StreamReader {
         let (sender, receiver) = watch::channel(checkpoint.clone());
 
         if self.config.should_load_progress {
-            let mut loaded_timestamp = chrono::Duration::max_value();
+            let mut loaded_timestamp = chrono::Duration::MAX;
             for stream in &self.stream_id_vec {
                 if let Some(timestamp) = self
                     .config
@@ -135,7 +144,7 @@ impl StreamReader {
                     loaded_timestamp = min(timestamp, loaded_timestamp);
                 }
             }
-            if loaded_timestamp != chrono::Duration::max_value() {
+            if loaded_timestamp != chrono::Duration::MAX {
                 window_begin = max(window_begin, loaded_timestamp);
             }
         }
@@ -199,7 +208,7 @@ impl StreamReader {
     ) -> anyhow::Result<()> {
         let mut sleep_after_timeout = BASIC_TIMEOUT_SLEEP_MS;
 
-        let mut next_state = None;
+        let mut next_state = PagingState::start();
         let mut page_no = 0;
         loop {
             let state_clone = next_state.clone();
@@ -214,18 +223,19 @@ impl StreamReader {
                 )
                 .await;
             match query_res {
-                Ok(x) => {
+                Ok((query_result, next_paging_state)) => {
                     sleep_after_timeout = BASIC_TIMEOUT_SLEEP_MS;
                     page_no += 1;
-                    if let Some(rows) = x.rows {
-                        let schema = CDCRowSchema::new(&x.col_specs);
-
-                        for row in rows {
-                            consumer.consume_cdc(CDCRow::from_row(row, &schema)).await?;
-                        }
+                    let query_rows_result = query_result.into_rows_result()?;
+                    let schema = CDCRowSchema::new(query_rows_result.column_specs());
+                    let rows = query_rows_result.rows::<Row>()?;
+                    for row in rows {
+                        consumer
+                            .consume_cdc(CDCRow::from_row(row?, &schema))
+                            .await?;
                     }
-                    match x.paging_state {
-                        Some(state) => next_state = Some(state),
+                    match next_paging_state {
+                        Some(state) => next_state = state,
                         None => break,
                     }
                 }
@@ -359,7 +369,7 @@ mod tests {
         let mut rows = session
             .query_iter(query_stream_id, ())
             .await?
-            .into_typed::<(StreamID,)>();
+            .rows_stream::<(StreamID,)>()?;
 
         let mut stream_ids_vec = Vec::new();
         while let Some(row) = rows.next().await {
@@ -407,8 +417,8 @@ mod tests {
             ids: &[StreamID],
             window_begin: &value::CqlTimestamp,
             window_end: &value::CqlTimestamp,
-            paging_state: Option<Bytes>,
-        ) -> Result<QueryResult, QueryError> {
+            paging_state: PagingState,
+        ) -> Result<(QueryResult, Option<PagingState>), QueryError> {
             if self.counter.fetch_sub(1, Relaxed) >= 0 {
                 let read_timeout = DbError::ReadTimeout {
                     consistency: Default::default(),
@@ -418,9 +428,15 @@ mod tests {
                 };
                 Err(QueryError::DbError(read_timeout, String::new()))
             } else {
-                self.session
-                    .execute_paged(statement, (ids, window_begin, window_end), paging_state)
-                    .await
+                let (query_result, paging_state_response) = self
+                    .session
+                    .execute_single_page(statement, (ids, window_begin, window_end), paging_state)
+                    .await?;
+                let next_paging_state = match paging_state_response {
+                    PagingStateResponse::HasMorePages { state } => Some(state),
+                    PagingStateResponse::NoMorePages => None,
+                };
+                Ok((query_result, next_paging_state))
             }
         }
     }
@@ -525,7 +541,7 @@ mod tests {
         let second_ago_timestamp = chrono::Duration::milliseconds(second_ago.timestamp_millis());
         insert_before_upper_timestamp_query.set_timestamp(second_ago_timestamp.num_microseconds());
         shared_session
-            .query(insert_before_upper_timestamp_query, ())
+            .query_unpaged(insert_before_upper_timestamp_query, ())
             .await
             .unwrap();
 
@@ -541,7 +557,7 @@ mod tests {
             chrono::Duration::milliseconds(second_later.timestamp_millis());
         insert_after_upper_timestamp_query.set_timestamp(second_later_timestamp.num_microseconds());
         shared_session
-            .query(insert_after_upper_timestamp_query, ())
+            .query_unpaged(insert_after_upper_timestamp_query, ())
             .await
             .unwrap();
         let fetched_rows = Arc::new(Mutex::new(vec![]));


### PR DESCRIPTION
Hi,

For my project I need to bump scylla driver to latest version (0.15.1 as of now), and since it also use scylla-cdc-rust, then I try to update it too...

Mainly just updating [deserialization mechanism](https://rust-driver.docs.scylladb.com/stable/migration-guides/0.15-deserialization.html) and replacing `query`/`execute` with `query_unpaged`, `execute_unpaged`, `query_iter` and `execute_single_page` (need reviews here, my adjustment might be incorrect)
