### PR TITLE
add sleep after failure to fetch_generations_continuously

### DIFF
--- a/scylla-cdc-printer/src/printer.rs
+++ b/scylla-cdc-printer/src/printer.rs
@@ -28,7 +28,7 @@ impl Consumer for PrinterConsumer {
                 if let Some(value) = data.get_value(column) {
                     row_to_print.push_str(&print_field(
                         value_field_name.as_str(),
-                        format!("{:?}", value).as_str(),
+                        format!("{value:?}").as_str(),
                     ));
                 } else {
                     row_to_print.push_str(&print_field(value_field_name.as_str(), "null"));
@@ -97,7 +97,7 @@ fn print_row_change_header(data: &CDCRow<'_>) -> String {
 }
 
 fn print_field(field_name: &str, field_value: &str) -> String {
-    let mut field_to_print = format!("│ {}: {}", field_name, field_value);
+    let mut field_to_print = format!("│ {field_name}: {field_value}");
     let left_spaces: i64 =
         OUTPUT_WIDTH - field_name.chars().count() as i64 - field_value.chars().count() as i64;
 

--- a/scylla-cdc-replicator/src/main.rs
+++ b/scylla-cdc-replicator/src/main.rs
@@ -79,7 +79,7 @@ async fn main() -> anyhow::Result<()> {
             // The only way this could have happened is an error in on of the CDCLogReaders so we
             // stop all of them.
             result = res.unwrap();
-            println!("{:?}", result);
+            println!("{result:?}");
         }
     }
 
@@ -87,7 +87,7 @@ async fn main() -> anyhow::Result<()> {
     while let Some(res) = handles.next().await {
         if res.is_err() {
             result = res;
-            println!("{:?}", result);
+            println!("{result:?}");
         }
     }
     result

--- a/scylla-cdc-test-utils/src/lib.rs
+++ b/scylla-cdc-test-utils/src/lib.rs
@@ -16,12 +16,12 @@ pub fn now() -> chrono::Duration {
 pub fn unique_name() -> String {
     let cnt = UNIQUE_COUNTER.fetch_add(1, Ordering::SeqCst);
     let name = format!("test_rust_{}_{}", now().num_seconds(), cnt);
-    println!("unique_name: {}", name);
+    println!("unique_name: {name}");
     name
 }
 
 fn get_create_table_query() -> String {
-    format!("CREATE TABLE IF NOT EXISTS {} (pk int, t int, v text, s text, PRIMARY KEY (pk, t)) WITH cdc = {{'enabled':true}};", TEST_TABLE)
+    format!("CREATE TABLE IF NOT EXISTS {TEST_TABLE} (pk int, t int, v text, s text, PRIMARY KEY (pk, t)) WITH cdc = {{'enabled':true}};")
 }
 
 pub async fn create_test_db(
@@ -31,7 +31,7 @@ pub async fn create_test_db(
 ) -> anyhow::Result<String> {
     let ks = unique_name();
     let mut create_keyspace_query = Statement::new(format!(
-        "CREATE KEYSPACE IF NOT EXISTS {} WITH REPLICATION = {{'class': 'SimpleStrategy', 'replication_factor': {}}};", ks, replication_factor
+        "CREATE KEYSPACE IF NOT EXISTS {ks} WITH REPLICATION = {{'class': 'SimpleStrategy', 'replication_factor': {replication_factor}}};"
     ));
     create_keyspace_query.set_consistency(Consistency::All);
 
@@ -52,8 +52,7 @@ pub async fn populate_simple_db_with_pk(session: &Arc<Session>, pk: u32) -> anyh
         session
             .query_unpaged(
                 format!(
-                    "INSERT INTO {} (pk, t, v, s) VALUES ({}, {}, 'val{}', 'static{}');",
-                    TEST_TABLE, pk, i, i, i
+                    "INSERT INTO {TEST_TABLE} (pk, t, v, s) VALUES ({pk}, {i}, 'val{i}', 'static{i}');",
                 ),
                 &[],
             )

--- a/scylla-cdc/src/cdc_types.rs
+++ b/scylla-cdc/src/cdc_types.rs
@@ -55,7 +55,7 @@ pub struct StreamID {
 impl fmt::Display for StreamID {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let encoded_stream_id = hex::encode(self.id.clone());
-        write!(f, "{}", encoded_stream_id)
+        write!(f, "{encoded_stream_id}")
     }
 }
 

--- a/scylla-cdc/src/consumer.rs
+++ b/scylla-cdc/src/consumer.rs
@@ -320,12 +320,11 @@ mod tests {
     fn construct_single_value_table_query() -> String {
         format!(
             "
-    CREATE TABLE IF NOT EXISTS {}(
+    CREATE TABLE IF NOT EXISTS {TEST_SINGLE_VALUE_TABLE}(
     pk int,
     ck int,
     v int,
-    PRIMARY KEY(pk, ck)) WITH cdc = {};",
-            TEST_SINGLE_VALUE_TABLE, CDC_CONFIG
+    PRIMARY KEY(pk, ck)) WITH cdc = {CDC_CONFIG};"
         )
     }
 
@@ -346,12 +345,11 @@ mod tests {
     fn construct_single_collection_table_query() -> String {
         format!(
             "
-    CREATE TABLE IF NOT EXISTS {}(
+    CREATE TABLE IF NOT EXISTS {TEST_SINGLE_COLLECTION_TABLE}(
     pk int,
     ck int,
     vs set<int>,
-    PRIMARY KEY(pk, ck)) WITH cdc = {};",
-            TEST_SINGLE_COLLECTION_TABLE, CDC_CONFIG
+    PRIMARY KEY(pk, ck)) WITH cdc = {CDC_CONFIG};"
         )
     }
 
@@ -359,8 +357,7 @@ mod tests {
         session
             .query_unpaged(
                 format!(
-                    "INSERT INTO {} (pk, ck, vs) VALUES (?, ?, ?);",
-                    TEST_SINGLE_COLLECTION_TABLE
+                    "INSERT INTO {TEST_SINGLE_COLLECTION_TABLE} (pk, ck, vs) VALUES (?, ?, ?);"
                 ),
                 (1, 2, vec![1, 2]),
             )
@@ -389,10 +386,7 @@ mod tests {
     async fn test_query() {
         let session = setup().await.unwrap();
         let mut result = session
-            .query_iter(
-                format!("SELECT * FROM {};", TEST_SINGLE_VALUE_CDC_TABLE),
-                (),
-            )
+            .query_iter(format!("SELECT * FROM {TEST_SINGLE_VALUE_CDC_TABLE};"), ())
             .await
             .unwrap()
             .rows_stream::<Row>()
@@ -489,8 +483,7 @@ mod tests {
                     "SELECT ck, pk, v, \"cdc$deleted_v\",\
                                   \"cdc$time\", \"cdc$stream_id\", \"cdc$batch_seq_no\", \
                                   \"cdc$ttl\", \"cdc$end_of_batch\", \"cdc$operation\"\
-                                  FROM {};",
-                    TEST_SINGLE_VALUE_CDC_TABLE
+                                  FROM {TEST_SINGLE_VALUE_CDC_TABLE};"
                 ),
                 (),
             )
@@ -526,10 +519,7 @@ mod tests {
     async fn test_take_value() {
         let session = setup().await.unwrap();
         let result = session
-            .query_unpaged(
-                format!("SELECT * FROM {};", TEST_SINGLE_VALUE_CDC_TABLE),
-                (),
-            )
+            .query_unpaged(format!("SELECT * FROM {TEST_SINGLE_VALUE_CDC_TABLE};"), ())
             .await
             .unwrap()
             .into_rows_result()
@@ -549,8 +539,7 @@ mod tests {
         session
             .query_unpaged(
                 format!(
-                    "UPDATE {} SET vs = vs - ? WHERE pk = ? AND ck = ?",
-                    TEST_SINGLE_COLLECTION_TABLE
+                    "UPDATE {TEST_SINGLE_COLLECTION_TABLE} SET vs = vs - ? WHERE pk = ? AND ck = ?"
                 ),
                 (vec![2], 1, 2),
             )
@@ -558,8 +547,7 @@ mod tests {
             .unwrap();
         // We must allow filtering in order to search by cdc$operation.
         let result = session
-            .query_unpaged(format!("SELECT * FROM {} WHERE \"cdc$operation\" = ? AND pk = ? AND ck = ? ALLOW FILTERING;",
-                           TEST_SINGLE_COLLECTION_CDC_TABLE), (OperationType::RowUpdate as i8, 1, 2))
+            .query_unpaged(format!("SELECT * FROM {TEST_SINGLE_COLLECTION_CDC_TABLE} WHERE \"cdc$operation\" = ? AND pk = ? AND ck = ? ALLOW FILTERING;"), (OperationType::RowUpdate as i8, 1, 2))
             .await
             .unwrap()
             .into_rows_result()

--- a/scylla-cdc/src/stream_generations.rs
+++ b/scylla-cdc/src/stream_generations.rs
@@ -291,13 +291,12 @@ mod tests {
     fn construct_generation_table_query() -> String {
         format!(
             "
-    CREATE TABLE IF NOT EXISTS {}(
+    CREATE TABLE IF NOT EXISTS {TEST_GENERATION_TABLE}(
     key text,
     time timestamp,
     expired timestamp,
     PRIMARY KEY (key, time)
-) WITH CLUSTERING ORDER BY (time DESC);",
-            TEST_GENERATION_TABLE
+) WITH CLUSTERING ORDER BY (time DESC);"
         )
     }
 
@@ -305,21 +304,19 @@ mod tests {
     fn construct_stream_table_query() -> String {
         format!(
             "
-    CREATE TABLE IF NOT EXISTS {} (
+    CREATE TABLE IF NOT EXISTS {TEST_STREAM_TABLE} (
     time timestamp,
     range_end bigint,
     streams frozen<set<blob>>,
     PRIMARY KEY (time, range_end)
 ) WITH CLUSTERING ORDER BY (range_end ASC);",
-            TEST_STREAM_TABLE
         )
     }
 
     async fn insert_generation_timestamp(session: &Session, generation: i64) {
         let query = new_distributed_system_query(
             format!(
-                "INSERT INTO {} (key, time, expired) VALUES ('timestamps', ?, NULL);",
-                TEST_GENERATION_TABLE
+                "INSERT INTO {TEST_GENERATION_TABLE} (key, time, expired) VALUES ('timestamps', ?, NULL);",
             ),
             session,
         )
@@ -342,8 +339,7 @@ mod tests {
 
         let query = new_distributed_system_query(
             format!(
-                "INSERT INTO {}(time, range_end, streams) VALUES (?, -1, {{{}, {}}});",
-                TEST_STREAM_TABLE, TEST_STREAM_1, TEST_STREAM_2
+                "INSERT INTO {TEST_STREAM_TABLE}(time, range_end, streams) VALUES (?, -1, {{{TEST_STREAM_1}, {TEST_STREAM_2}}});"
             ),
             session,
         )

--- a/scylla-cdc/src/stream_generations.rs
+++ b/scylla-cdc/src/stream_generations.rs
@@ -198,12 +198,18 @@ impl GenerationFetcher {
                                         None => sleep(sleep_interval).await,
                                         Some(generation) => break generation.clone(),
                                     },
-                                    _ => warn!("Failed to fetch all generations"),
+                                    _ => {
+                                        warn!("Failed to fetch all generations");
+                                        sleep(sleep_interval).await
+                                    }
                                 }
                             }
                         }
                     }
-                    _ => warn!("Failed to fetch generation by timestamp"),
+                    _ => {
+                        warn!("Failed to fetch generation by timestamp");
+                        sleep(sleep_interval).await
+                    }
                 }
             };
             if generation_sender.send(generation.clone()).await.is_err() {
@@ -215,7 +221,10 @@ impl GenerationFetcher {
                     match self.fetch_next_generation(&generation).await {
                         Ok(Some(generation)) => break generation,
                         Ok(None) => sleep(sleep_interval).await,
-                        _ => warn!("Failed to fetch next generation"),
+                        _ => {
+                            warn!("Failed to fetch next generation");
+                            sleep(sleep_interval).await
+                        }
                     }
                 };
                 if generation_sender.send(generation.clone()).await.is_err() {

--- a/scylla-cdc/src/stream_reader.rs
+++ b/scylla-cdc/src/stream_reader.rs
@@ -108,11 +108,10 @@ impl StreamReader {
         mut consumer: Box<dyn Consumer>,
     ) -> anyhow::Result<()> {
         let query = format!(
-            "SELECT * FROM {}.{}_scylla_cdc_log \
+            "SELECT * FROM {keyspace}.{table_name}_scylla_cdc_log \
             WHERE \"cdc$stream_id\" in ? \
             AND \"cdc$time\" >= minTimeuuid(?) \
-            AND \"cdc$time\" < minTimeuuid(?)  BYPASS CACHE",
-            keyspace, table_name
+            AND \"cdc$time\" < minTimeuuid(?)  BYPASS CACHE"
         );
         let query_base = self.session.prepare_statement(query).await?;
         let mut window_begin = self.config.lower_timestamp;
@@ -362,10 +361,8 @@ mod tests {
     }
 
     async fn get_cdc_stream_id(session: &Arc<Session>) -> anyhow::Result<Vec<StreamID>> {
-        let query_stream_id = format!(
-            "SELECT DISTINCT \"cdc$stream_id\" FROM {}_scylla_cdc_log;",
-            TEST_TABLE
-        );
+        let query_stream_id =
+            format!("SELECT DISTINCT \"cdc$stream_id\" FROM {TEST_TABLE}_scylla_cdc_log;");
 
         let mut rows = session
             .query_iter(query_stream_id, ())
@@ -481,15 +478,15 @@ mod tests {
             if pk == partition_key_1 as i32 {
                 assert_eq!(pk, partition_key_1 as i32);
                 assert_eq!(t, count1);
-                assert_eq!(v.to_string(), format!("val{}", count1));
-                assert_eq!(s.to_string(), format!("static{}", count1));
+                assert_eq!(v.to_string(), format!("val{count1}"));
+                assert_eq!(s.to_string(), format!("static{count1}"));
                 count1 += 1;
                 row_count_with_pk1 += 1;
             } else {
                 assert_eq!(pk, partition_key_2 as i32);
                 assert_eq!(t, count2);
-                assert_eq!(v.to_string(), format!("val{}", count2));
-                assert_eq!(s.to_string(), format!("static{}", count2));
+                assert_eq!(v.to_string(), format!("val{count2}"));
+                assert_eq!(s.to_string(), format!("static{count2}"));
                 count2 += 1;
                 row_count_with_pk2 += 1;
             }
@@ -526,8 +523,8 @@ mod tests {
             let (pk, s, t, v) = row.clone();
             assert_eq!(pk, partition_key as i32);
             assert_eq!(t, count as i32);
-            assert_eq!(v.to_string(), format!("val{}", count));
-            assert_eq!(s.to_string(), format!("static{}", count));
+            assert_eq!(v.to_string(), format!("val{count}"));
+            assert_eq!(s.to_string(), format!("static{count}"));
         }
     }
 
@@ -616,8 +613,8 @@ mod tests {
             let (pk, s, t, v) = row.clone();
             assert_eq!(pk, partition_key as i32);
             assert_eq!(t, count as i32);
-            assert_eq!(v.to_string(), format!("val{}", count));
-            assert_eq!(s.to_string(), format!("static{}", count));
+            assert_eq!(v.to_string(), format!("val{count}"));
+            assert_eq!(s.to_string(), format!("static{count}"));
         }
     }
 }


### PR DESCRIPTION
If we lose the connection to the DB while fetching the next generation, stdout is spammed with warnings and the process stops responding to ctrl-c signals. By adding a sleep with the same interval as in the case of expected fail while fetching we alleviate both of these problems.

Fixes: VECTOR-161