### PR TITLE
Release 0.4.1

### DIFF
--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scylla = "1.0"
+scylla = "1.3.1"
 scylla-cdc = { version = "0.4.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 chrono = "0.4.19"

--- a/scylla-cdc-printer/Cargo.toml
+++ b/scylla-cdc-printer/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scylla-cdc-printer"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 scylla = "1.3.1"
-scylla-cdc = { version = "0.4.0", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.4.1", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 chrono = "0.4.19"
 futures = "0.3.17"

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "scylla-cdc-replicator"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 scylla = "1.3.1"
-scylla-cdc = { version = "0.4.0", path = "../scylla-cdc" }
+scylla-cdc = { version = "0.4.1", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 async-trait = "0.1.51"
 anyhow = "1.0.48"

--- a/scylla-cdc-replicator/Cargo.toml
+++ b/scylla-cdc-replicator/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-scylla = "1.0"
+scylla = "1.3.1"
 scylla-cdc = { version = "0.4.0", path = "../scylla-cdc" }
 tokio = { version = "1.1.0", features = ["full"] }
 async-trait = "0.1.51"

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc-test-utils"
-version = "0.3.0"
+version = "0.4.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/scylla-cdc-test-utils/Cargo.toml
+++ b/scylla-cdc-test-utils/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.48"
 chrono = "0.4.19"
-scylla = "1.0"
+scylla = "1.3.1"

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scylla-cdc"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Library for consuming ScyllaDB CDC log for Rust"
 repository = "https://github.com/scylladb/scylla-cdc-rust"

--- a/scylla-cdc/Cargo.toml
+++ b/scylla-cdc/Cargo.toml
@@ -13,7 +13,7 @@ license = "Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.48"
-scylla = "1.0"
+scylla = "1.3.1"
 tokio = { version = "1.1.0", features = [
     "rt",
     "io-util",

--- a/scylla-cdc/src/consumer.rs
+++ b/scylla-cdc/src/consumer.rs
@@ -168,7 +168,7 @@ pub struct CDCRow<'schema> {
 }
 
 impl CDCRow<'_> {
-    pub fn from_row(row: Row, schema: &CDCRowSchema) -> CDCRow {
+    pub fn from_row(row: Row, schema: &CDCRowSchema) -> CDCRow<'_> {
         // If cdc read was successful, these default values will not be used.
         let mut stream_id_vec = vec![];
         let mut time = uuid::Uuid::default();


### PR DESCRIPTION
# Contents

1. A bug (_deathloop_) has been fixed (#133).
2. Rust Driver version is bumped to 1.3.1.